### PR TITLE
pin vllm:rhoai-2.16-cuda release tag

### DIFF
--- a/bootstrap/llms-deployment/servingruntime-granite-30-8b-instruct.yaml
+++ b/bootstrap/llms-deployment/servingruntime-granite-30-8b-instruct.yaml
@@ -33,7 +33,7 @@ spec:
       env:
         - name: HF_HOME
           value: /tmp/hf_home
-      image: 'quay.io/modh/vllm:rhoai-2.16-cuda'
+      image: 'quay.io/modh/vllm:rhoai-2.16-cuda-99fa7014cb9d96d4c64efcf504526d6cadbc400c'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/bootstrap/llms-deployment/servingruntime-parasol-chat.yaml
+++ b/bootstrap/llms-deployment/servingruntime-parasol-chat.yaml
@@ -33,7 +33,7 @@ spec:
       env:
         - name: HF_HOME
           value: /tmp/hf_home
-      image: 'quay.io/modh/vllm:rhoai-2.16-cuda'
+      image: 'quay.io/modh/vllm:rhoai-2.16-cuda-99fa7014cb9d96d4c64efcf504526d6cadbc400c'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/bootstrap/llms-deployment/servingruntime-parasol-instruct.yaml
+++ b/bootstrap/llms-deployment/servingruntime-parasol-instruct.yaml
@@ -33,7 +33,7 @@ spec:
       env:
         - name: HF_HOME
           value: /tmp/hf_home
-      image: 'quay.io/modh/vllm:rhoai-2.16-cuda'
+      image: 'quay.io/modh/vllm:rhoai-2.16-cuda-99fa7014cb9d96d4c64efcf504526d6cadbc400c'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/bootstrap/llms-deployment/servingruntime-rad-vllm-template.yaml
+++ b/bootstrap/llms-deployment/servingruntime-rad-vllm-template.yaml
@@ -53,7 +53,7 @@ objects:
           env:
             - name: HF_HOME
               value: /tmp/hf_home
-          image: quay.io/modh/vllm:rhoai-2.16-cuda
+          image: quay.io/modh/vllm:rhoai-2.16-cuda-99fa7014cb9d96d4c64efcf504526d6cadbc400c
           name: kserve-container
           ports:
             - containerPort: 8080

--- a/bootstrap/llms-deployment/servingruntime-rad-vllm.yaml
+++ b/bootstrap/llms-deployment/servingruntime-rad-vllm.yaml
@@ -29,7 +29,7 @@ spec:
       env:
         - name: HF_HOME
           value: /tmp/hf_home
-      image: quay.io/modh/vllm:rhoai-2.16-cuda
+      image: quay.io/modh/vllm:rhoai-2.16-cuda-99fa7014cb9d96d4c64efcf504526d6cadbc400c
       name: kserve-container
       ports:
         - containerPort: 8080


### PR DESCRIPTION
The vllm team has recently pushed some new changes to https://quay.io/repository/modh/vllm/tag/rhoai-2.16-cuda that have broken AI model hosting in the Java4AI workshop.  

This change pins the vllm release tag to a value that is less likely to be updated (and/or broken) in the future.

We may need to create an extra repo on quay (as a backup) if these vllm release tags continue to be altered without notice.